### PR TITLE
#94 - Better error handling for inotify file scanning

### DIFF
--- a/fileconveyor/fsmonitor_inotify.py
+++ b/fileconveyor/fsmonitor_inotify.py
@@ -217,9 +217,7 @@ class FSMonitorInotifyProcessEvent(ProcessEvent):
                 else:
                     self.fsmonitor_ref.pathscanner_files_modified.append(t)
             except OSError, e:
-                print "Caught a OSError, probably a file doesn't exist"
-                print pathname
-
+                self.fsmonitor_ref.logger.warn("inotify caught an OSError, probably a file does not exist at '%s'." % (pathname))
 
     @classmethod
     def __ensure_unicode(cls, event):


### PR DESCRIPTION
I've been having this issue like crazy and it crashes fileconveyor on Ubuntu 10.04 with Python 2.6.5. I tested fringedgentian's suggestion and can confirm this has fixed the issues.
