### PR TITLE
Checking if classname has been set

### DIFF
--- a/fileconveyor/arbitrator.py
+++ b/fileconveyor/arbitrator.py
@@ -1158,8 +1158,13 @@ class Arbitrator(threading.Thread):
                 classname = module.TRANSPORTER_CLASS
                 module = __import__(module_name, globals(), locals(), [classname])
                 transporter_class = getattr(module, classname)
-            except AttributeError:
-                self.logger.error("The Transporter module '%s' was found, but its Transporter class '%s' could not be found."  % (module_name, classname))
+            except AttributeError:`
+                try:
+                    classname
+                except NameError:
+                    self.logger.error("The Transporter module '%s' was found, but its Transporter class could not be found."  % (module_name))
+                else:
+                    self.logger.error("The Transporter module '%s' was found, but its Transporter class '%s' could not be found."  % (module_name, classname))
         return transporter_class
 
 


### PR DESCRIPTION
As mentioned in issue 162 the error provided does not point to the actual problem at hand. This patch checks if classname has been set before it's used

The problem occurs when TRANSPORTER_CLASS is not available in module, which happened on my entirely fresh installation of debian 7 today.