### PR TITLE
Remove illegal char

### DIFF
--- a/fileconveyor/arbitrator.py
+++ b/fileconveyor/arbitrator.py
@@ -1158,7 +1158,7 @@ class Arbitrator(threading.Thread):
                 classname = module.TRANSPORTER_CLASS
                 module = __import__(module_name, globals(), locals(), [classname])
                 transporter_class = getattr(module, classname)
-            except AttributeError:`
+            except AttributeError:
                 try:
                     classname
                 except NameError:


### PR DESCRIPTION
The arbitrator script currently throws a fatal exception for me, but removing this char fixed it. I'm not sure whether it was deliberately included or not since I'm not a Python person :)